### PR TITLE
add sample pre-commit hook

### DIFF
--- a/contrib/pre-commit
+++ b/contrib/pre-commit
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -ex
+
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+
+# change this to however you wish to activate your venv
+# shellcheck source=/dev/null  # hush.
+[ -z "$VIRTUAL_ENV" ] && . "$PROJECT_ROOT/.venv/bin/activate"
+
+black .
+isort .
+pyright


### PR DESCRIPTION
This PR adds a sample pre-commit hook that can simply be placed in the `.git` folder to help with following formatting guidelines and hopefully make the lint workflow fail less often.